### PR TITLE
hotfix/2.0.4 remoção de info do card sobre horários

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "base-project",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base-project",
   "private": true,
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/InfoCard/InfoCard.jsx
+++ b/src/components/InfoCard/InfoCard.jsx
@@ -27,8 +27,7 @@ export function InfoCard(){
             <div className="fixed bottom-0 translate-x-1/2 right-1/2 w-11/12 z-[401]">
                 <div className={styles.routesCard}>
                     <p className='text-[#707070] text-sm'>Você está em</p>
-                    <h1 className="text-xl font-semibold">{name}</h1>
-                    <p className="text-sm mb-3">Aberta todos os dias entre 04:00 e 00h</p>
+                    <h1 className="text-xl font-semibold mb-3">{name}</h1>
                     <ul className={styles.routeList}>
                          {!routes ? <>
                             <Oval


### PR DESCRIPTION
Remoção da informação do horário de funcionamento no Card para selecionar trips: 

Antes: 
<img width="174" alt="Captura de Tela 2022-12-21 às 14 02 28" src="https://user-images.githubusercontent.com/82231197/208962487-c1f1bdb3-393d-4078-9b7e-5f068e574fea.png">

 Depois: 
 
<img width="292" alt="Captura de Tela 2022-12-21 às 14 03 23" src="https://user-images.githubusercontent.com/82231197/208962640-56254398-39d1-4eda-851b-8fd65efe7a7d.png">
