### PR TITLE
release/2.2.6-baseURL-setada-por-hostname

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "base-project",
-  "version": "2.1.6",
+  "version": "2.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "base-project",
-      "version": "2.1.6",
+      "version": "2.2.6",
       "dependencies": {
         "@turf/turf": "^6.5.0",
         "axios": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base-project",
   "private": true,
-  "version": "2.1.6",
+  "version": "2.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/InfoCard/InfoCard.jsx
+++ b/src/components/InfoCard/InfoCard.jsx
@@ -8,6 +8,7 @@ import axios from 'axios'
 import { RoutesContext } from '../../hooks/getRoutes'
 import { Oval } from 'react-loader-spinner'
 import { ThemeContext } from '../../hooks/getTheme'
+import { api } from '../../services/api'
 
 export function InfoCard(){
     const [name, setName] = useState()
@@ -18,7 +19,7 @@ export function InfoCard(){
 
 
     useEffect(() => {
-        axios.get('https://api.mobilidade.rio/gtfs/stops/?stop_code=' + code.toUpperCase())
+        api.get('/stops/?stop_code=' + code.toUpperCase())
                .then(response => setName(response.data.results[0].stop_name)) 
     }, [code])
 

--- a/src/hooks/getCode.jsx
+++ b/src/hooks/getCode.jsx
@@ -1,9 +1,7 @@
 import { createContext, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {toast } from 'react-toastify'
-
-import axios from 'axios'
-
+import { api } from "../services/api";
 
 export const CodeContext = createContext()
 
@@ -29,7 +27,7 @@ export function CodeProvider({ children }) {
     }, [])
     // CHECA SE CÓDIGO PESQUISADO EXISTE
     function checkCode() {
-        axios.get("https://api.mobilidade.rio/gtfs/stops/?stop_code=" + code.toUpperCase())
+        api.get("/stops/?stop_code=" + code.toUpperCase())
             .then(response => {
                 if (response.data.count == 0 && code.length == 4) {
                     toast.error(`O código ${code.toUpperCase()} não existe`, {

--- a/src/hooks/getRoutes.jsx
+++ b/src/hooks/getRoutes.jsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { CodeContext } from "./getCode";
-import axios from "axios";
-
+import { api } from "../services/api";
 export const RoutesContext = createContext()
 
 
@@ -13,15 +12,15 @@ export function RoutesProvider({children}){
 
      
     useEffect(() => {
-        axios
-            .get("https://api.mobilidade.rio/gtfs/stops/?stop_code=" + code.toUpperCase())
+        api
+            .get("/stops/?stop_code=" + code.toUpperCase())
             .then(response => setStopId(response.data.results[0].stop_id))
     }, [code])
 
 
     let allTrips = []
    async function getMultiplePages(url) {
-       await  axios
+       await  api
             .get(url)
             .then(({ data }) => {
                 data.results.forEach((item) => { allTrips.push(item) })
@@ -35,7 +34,7 @@ export function RoutesProvider({children}){
     }
     
     useEffect(() => {
-        getMultiplePages("https://api.mobilidade.rio/gtfs/stop_times/?stop_id=" + stopId)
+        getMultiplePages("/stop_times/?stop_id=" + stopId)
     }, [stopId])
     
 

--- a/src/hooks/getShape.jsx
+++ b/src/hooks/getShape.jsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { TripContext } from "./getTrips";
 import { CodeContext } from "./getCode";
 import * as turf from '@turf/turf'
-import axios from 'axios'
+import { api } from "../services/api";
 
 
 export const ShapeContext = createContext()
@@ -17,12 +17,12 @@ export function ShapeProvider({ children }) {
 
 
     useEffect(() => {
-        axios.get('https://api.mobilidade.rio/gtfs/stops/?stop_code=' + code.toUpperCase())
+        api.get('/stops/?stop_code=' + code.toUpperCase())
             .then(response => setStopCoords([response.data.results[0].stop_lon, response.data.results[0].stop_lat]))
     }, [code])
 
     useEffect(() => {
-        axios.get('https://api.mobilidade.rio/gtfs/trips/?trip_id=' + trip)
+        api.get('/trips/?trip_id=' + trip)
             .then(reponse => setShape(reponse.data.results[0].shape_id))
     }, [trip])
 
@@ -35,7 +35,7 @@ export function ShapeProvider({ children }) {
                 let response = { data: {} }
 
                 do {
-                    response = await axios.get(response.data.next || "https://api.mobilidade.rio/gtfs/shapes/?shape_id=" + shape)
+                    response = await api.get(response.data.next || "/shapes/?shape_id=" + shape)
                     points.push(...response.data.results)
                     i += 20
                 } while (response.data.next);

--- a/src/hooks/getTheme.jsx
+++ b/src/hooks/getTheme.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { CodeContext } from "./getCode";
 import { RoutesContext } from "./getRoutes";
-import axios from "axios";
+import { api } from "../services/api";
 
 
 
@@ -17,7 +17,7 @@ export function ThemeProvider({ children }) {
     const {stopId} = useContext(RoutesContext)
 
     useEffect(() => {
-        axios.get('https://api.mobilidade.rio/gtfs/stop_times/?stop_id=' + stopId)
+        api.get('/stop_times/?stop_id=' + stopId)
             .then(response => setRouteType(response.data.results[0].trip_id.route_id.route_type))
     }, [code])
 

--- a/src/hooks/getTrips.jsx
+++ b/src/hooks/getTrips.jsx
@@ -1,6 +1,7 @@
 import { createContext, useEffect, useState , useContext} from "react";
 import axios from 'axios'
 import {  RoutesContext } from "./getRoutes";
+import { api } from "../services/api";
 
 
 export const TripContext = createContext()
@@ -20,7 +21,7 @@ export function TripProvider({ children }) {
 
     let allStops = []
     async function getAllStops(url) {
-        await axios
+        await api
             .get(url)
             .then(({ data }) => {
                 data.results.forEach((item) => { allStops.push(item) })
@@ -35,9 +36,9 @@ export function TripProvider({ children }) {
 
     // GET SEQUENCESTOPS
     useEffect(() => {
-        axios.get('https://api.mobilidade.rio/gtfs/trips/?trip_id=' + trip)
+        api.get('/trips/?trip_id=' + trip)
             .then(response => setStopInfo(response.data.results[0]))
-        getAllStops('https://api.mobilidade.rio/gtfs/stop_times/?trip_id='+trip)
+        getAllStops('/stop_times/?trip_id='+trip)
     }, [trip])
  
     useEffect(() => {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -23,6 +23,7 @@ import marker from '../assets/imgs/marker.svg'
 import "leaflet-routing-machine/dist/leaflet-routing-machine.css";
 import { useParams } from "react-router-dom";
 import { ShapeContext } from "../hooks/getShape";
+import { api } from "../services/api";
 
 export function Home() {
     const [center, setCenter] = useState()
@@ -61,7 +62,7 @@ export function Home() {
     }
 
     useEffect(() => {
-        axios.get('https://api.mobilidade.rio/gtfs/stops/?stop_code=' + code.toUpperCase())
+        api.get('/stops/?stop_code=' + code.toUpperCase())
             .then(response => setCenter([parseFloat(response.data.results[0].stop_lat), parseFloat(response.data.results[0].stop_lon)]))
     }, [code])
     

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,12 @@
+import axios from "axios";
+let baseURL = '';
+if (window.location.hostname === 'mobilidade.rio') {
+    baseURL = 'https://api.mobilidade.rio/gtfs'
+} else if (window.location.hostname === 'app.staging.mobilidade.rio') {
+    baseURL = 'https://api.dev.mobilidade.rio/gtfs'
+} else if(window.location.hostname === 'localhost') {
+    baseURL = 'https://api.dev.mobilidade.rio/gtfs'
+}
+
+
+export const api =  axios.create({baseURL})


### PR DESCRIPTION
Antes o axios fazia chamadas direto para a API em produção pela a url (https://api.mobilidade.rio/gtfs/), agora a alteração foi feita para o axios setar a baseURL de acordo com o hostname: 


<img width="586" alt="Captura de Tela 2022-12-26 às 16 20 35" src="https://user-images.githubusercontent.com/82231197/209578001-f38aab88-7604-4200-b7ae-756f96fc0aae.png">
