### PR TITLE
Bugfix/cor do layout sppo quando deveria ser brt e ajuste de linhas repetidas

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -26,7 +26,7 @@ export function Header(props) {
     const [codeIdentifier, setCodeIdentifier] = useState()
     const { setRoutes, setPlataforms} = useContext(RoutesContext)
     const { setResults, results, similarNames } = useContext(NameContext)
-    const {setTracked} = useContext(MovingMarkerContext)
+    const {setTracked, setInnerCircle} = useContext(MovingMarkerContext)
     function clearInfo() {
         setTrip('')
         setCode("")
@@ -38,6 +38,7 @@ export function Header(props) {
         setTracked()
         setTheme("sppo")
         setSppo()
+        setInnerCircle([])
 
     }
 
@@ -53,6 +54,7 @@ export function Header(props) {
         setRoutes()
         setPoints("")
         setTracked()
+        setInnerCircle([])
         if (event.target.value.length == 0) {
             setResults()
         }

--- a/src/hooks/getMovingMarkers.jsx
+++ b/src/hooks/getMovingMarkers.jsx
@@ -102,7 +102,7 @@ export function MovingMarkerProvider({ children }) {
     }, [realtime, radius])
 
     return (
-        <MovingMarkerContext.Provider value={{ center, tracked, setTracked, innerCircle }}>
+        <MovingMarkerContext.Provider value={{ center, tracked, setTracked, innerCircle, setInnerCircle }}>
             {children}
         </MovingMarkerContext.Provider>
     )

--- a/src/hooks/getRoutes.jsx
+++ b/src/hooks/getRoutes.jsx
@@ -29,18 +29,23 @@ export function RoutesProvider({ children }) {
         }
     }, [code])
 
-    let allTrips = []
     async function getMultiplePages(url) {
+        const filteredTrips = [];
         await api
             .get(url)
             .then(({ data }) => {
-                data.results.forEach((item) => { allTrips.push(item) })
+                data.results.forEach((item) => {
+                    const existingTrip = filteredTrips.find((trip) => trip.trip_id.trip_short_name === item.trip_id.trip_short_name);
+                    if (!existingTrip) {
+                        filteredTrips.push(item);
+                    }
+                });
                 if (data.next) {
-                    getMultiplePages(data.next)
+                    getMultiplePages(data.next);
+                } else {
+                    setRoutes([...filteredTrips]);
                 }
-                        setRoutes([...allTrips])
             })
-   
     }
 
     let allStations = []

--- a/src/hooks/getTheme.jsx
+++ b/src/hooks/getTheme.jsx
@@ -37,7 +37,7 @@ export function ThemeProvider({ children }) {
             setBrt();
             setTheme("")
         }
-    }, [routeType])
+    }, [routeType, stopId])
 
     return (
         <ThemeContext.Provider value={{ theme, setTheme, setSppo }}>


### PR DESCRIPTION
### Ajustes:
- Bug aonde se mantinha o tema do SPPO mesmo sendo pesquisado estação BRT. Bug ajustado adicionando mais um parâmetro no useEffect que disparava a diferenciação dos temas
- Bug que repetia as linhas. Por terem trip_id's diferentes o .map() incluía como se fosses novas trips, ajustado com um filtro pra checar se ja existia o trip_short_name mais de uma vez no array. Tentei fazer com trip_headsign mas por ter trips como 51 - Vila Militar e 52 - Vila Militar ele só mostrava uma delas, então a melhor solução foi utilizando o trip_short_name.