### PR TITLE
🚀  Release/2.3.2: Trips aparecem mesmo sem ETA e shapes para pontos iniciais corrigidos

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -25,7 +25,7 @@ export function Header(props) {
     const [codeIdentifier, setCodeIdentifier] = useState()
     const { setRoutes, setPlataforms} = useContext(RoutesContext)
     const { setResults, results, similarNames } = useContext(NameContext)
-    const {setTracked, setInnerCircle} = useContext(MovingMarkerContext)
+    const {setTracked, setArrivals} = useContext(MovingMarkerContext)
     const {stopFetching} = useContext(GPSContext)
     function clearInfo() {
         setTrip('')
@@ -42,6 +42,7 @@ export function Header(props) {
         setInnerCircle([])
         stopFetching()
         setRouteType()
+        setArrivals()
     }
 
     useEffect(() => {
@@ -58,6 +59,7 @@ export function Header(props) {
         setSequenceInfo()
         setTracked()
         setInnerCircle([])
+        setArrivals()
         if (event.target.value.length == 0) {
             setResults()
         }
@@ -103,7 +105,7 @@ export function Header(props) {
                                 <button className='absolute right-[12px] top-0 bottom-0' onClick={() => clearInfo()}>
                                     <GrFormClose />
                                 </button>
-                                <input type="text" placeholder='Selecione a estação de origem' className="rounded-lg py-3.5 px-3 w-full inputShadow" onKeyUp={searchNewCode} onPaste={searchNewCode} value={value} />
+                                <input type="text" placeholder='Selecione a estação de origem' className="rounded-lg py-3.5 px-3 w-full inputShadow" onKeyUp={searchNewCode} onPaste={searchNewCode} defaultValue={value} />
                                 {code.length === 0 || !results ? <></> :
                                     <ul className='bg-white border-[1px] rounded-lg absolute max-h-[120px] z-[1001] py-3.5 px-3 overflow-scroll'>
                                         {results.length == 0 ? <li>

--- a/src/components/InfoCard/InfoCard.jsx
+++ b/src/components/InfoCard/InfoCard.jsx
@@ -113,7 +113,7 @@ export function InfoCard() {
                                     strokeWidthSecondary={4}
 
                                 /> : sortedPlatforms.map((e) => Object.values(e).map((values) => {
-                                    return <li className='flex justify-between border-b py-2.5' onClick={() => { getMultiplePages(`/stop_times/?stop_id=${Object.keys(values)[0]}&service_id=${serviceId}`), infoLinha(), setSelectedPlatform(Object.keys(values)), activateLoader(), setGpsUrl('?stop_id=' + Object.keys(values)[0]) }}>
+                                    return <li key={Object.keys(values)[0]} className='flex justify-between border-b py-2.5' onClick={() => { getMultiplePages(`/stop_times/?stop_id=${Object.keys(values)[0]}&service_id=${serviceId}`), infoLinha(), setSelectedPlatform(Object.keys(values)), activateLoader(), setGpsUrl('?stop_id=' + Object.keys(values)[0]) }}>
                                         <div className={styles.routeName}>
                                             {!Object.values(values)[0].isConvencionais ? <>
                                                 <div className={` ${styles.shortName} + bg-[#F8AC04]`}>

--- a/src/components/MovingMarkers.jsx
+++ b/src/components/MovingMarkers.jsx
@@ -36,8 +36,6 @@ export default function BusMarker({ id, data, icon }) {
                         {/* <p></p> */}
                         <h1 className={data.hora[0] > 1 ? 'text-red-600' : ''}> Atualizado a <span className="font-bold">{data.hora[0]} min</span> atrás</h1>
                     </div>
-        
-                     {data.velocidade} km/h<br/>
                     {/* Sentido de {data.sentido === 1 ? `ida` : 'volta'} */} 
                 </Popup>
             </LeafletTrackingMarker>

--- a/src/hooks/getMovingMarkers.jsx
+++ b/src/hooks/getMovingMarkers.jsx
@@ -84,30 +84,31 @@ export function MovingMarkerProvider({ children }) {
 
 
 
-
     useEffect(() => {
-   
         if (routes && tracked) {
-                const arrivals = routes.reduce((acc, obj1) => {
-                    const matched = tracked.filter(obj2 =>
+            const arrivals = routes.map((obj1) => {
+                const matched = tracked.find((obj2) => {
+                    return (
                         obj1.trip_id.trip_short_name === obj2.linha &&
-                         obj1.trip_id.direction_id === obj2.sentido);
-                    
-                    if (matched.length > 0) {
-                        const sortedMatched = matched.sort((a, b) => a.chegada - b.chegada);
-                        const smallestEtas = sortedMatched.slice(0, 3).map(obj2 => obj2.chegada);
-                        const combinedObj = { ...obj1, smallestEtas };
-                        acc.push(combinedObj);
-                    }
-                    return acc;
-                }, []);
-                if(arrivals.length === 0){
-                    setArrivals(routes)
-                } else {
-                    setArrivals(arrivals)
+                        obj1.trip_id.direction_id === obj2.sentido
+                    );
+                });
+
+                if (matched) {
+                    const combinedObj = {
+                        ...obj1,
+                        smallestEtas: [matched.chegada],
+                    };
+                    return combinedObj;
                 }
+
+                return obj1;
+            });
+
+                setArrivals(arrivals);
         }
-    }, [tracked])
+    }, [tracked]);
+
 
 
     return (

--- a/src/hooks/getRoutes.jsx
+++ b/src/hooks/getRoutes.jsx
@@ -44,9 +44,9 @@ export function RoutesProvider({ children }) {
         return aNumber - bNumber;
     }
 
-    function activateLoader(){
-    setLoader(true)
-    setPlataforms([])
+    function activateLoader() {
+        setLoader(true)
+        setPlataforms([])
     }
 
     const filteredTrips = [];
@@ -62,9 +62,9 @@ export function RoutesProvider({ children }) {
                 });
                 if (data.next) {
                     getMultiplePages(data.next);
-                    
+
                 } else {
-                    if(locationType === 1){
+                    if (locationType === 1) {
                         getStations("/stop_times/?stop_id=" + stopId)
                     }
                     filteredTrips.sort(compareTripName)
@@ -79,18 +79,27 @@ export function RoutesProvider({ children }) {
         await api
             .get(url)
             .then(({ data }) => {
-                data.results.forEach((item) => { allStations.push(item) })
-              
-                    setStations(allStations)
+                data.results.forEach((item) => {
+                    const existingStation = allStations.find((e) => e.stop_id.stop_id === item.stop_id.stop_id);
+                    if (!existingStation) {
+                        allStations.push(item)
+                    }
+                })
+                if (data.next) {
+                    getStations(data.next)
+                } else {
+                    setStations([...allStations])
+                }
+
             })
-   
+
     }
 
 
     useEffect(() => {
         if (code && locationType != undefined) {
             if (locationType === 1) {
-                getStations("/stop_times/?stop_id=" + stopId)
+                getStations(`/stop_times/?stop_id=${stopId}&service_id=${serviceId}`)
                 setIsParent(true)
             } else if (locationType === 0) {
                 getMultiplePages(`/stop_times/?stop_id=${stopId}&service_id=${serviceId}`)
@@ -103,7 +112,7 @@ export function RoutesProvider({ children }) {
 
     useEffect(() => {
         if (routeType) {
-            if (locationType != null || locationType != undefined || stations != undefined ) {
+            if (locationType != null || locationType != undefined || stations != undefined) {
                 const iteratee = stations.map((e) => e)
                 const result = iteratee.reduce((acc, curr) => {
                     if (routeType.includes(3) && routeType.includes(702)) {
@@ -121,11 +130,11 @@ export function RoutesProvider({ children }) {
             }
         }
     }, [stations]);
-    
+
 
 
     return (
-        <RoutesContext.Provider value={{ routes, setRoutes, getMultiplePages, isParent, plataforms, setPlataforms, stations, setStations, loader, activateLoader}}>
+        <RoutesContext.Provider value={{ routes, setRoutes, getMultiplePages, isParent, plataforms, setPlataforms, stations, setStations, loader, activateLoader }}>
             {children}
         </RoutesContext.Provider>
     )

--- a/src/hooks/getShape.jsx
+++ b/src/hooks/getShape.jsx
@@ -10,47 +10,48 @@ export const ShapeContext = createContext()
 
 export function ShapeProvider({ children }) {
     const { stopCoords } = useContext(CodeContext)
-    const { shape } = useContext(TripContext)
+    const { shape, sequenceInfo } = useContext(TripContext)
     const [points, setPoints] = useState([])
-    
 
 
 
 
     useEffect(() => {
-        if(shape){
+        if (sequenceInfo) {
+            async function exec() {
+                let points = []
+                try {
+                    let i = 0
+                    let response = { data: {} }
 
-        async function exec() {
-            let points = []
-            try {
-                let i = 0
-                let response = { data: {} }
-
-                do {
-                    response = await api.get(response.data.next || "/shapes/?shape_id=" + shape)
-                    points.push(...response.data.results)
-                    i += 20
-                } while (response.data.next);
-
-
-                let longLat = points.map(p => [p.shape_pt_lon * 1, p.shape_pt_lat * 1])
-
-                var line = turf.lineString(longLat);
-                var pt = turf.point(stopCoords)
-                var splitter = turf.nearestPointOnLine(line, pt)
-                var split = turf.lineSplit(line, splitter);
+                    do {
+                        response = await api.get(response.data.next || "/shapes/?shape_id=" + shape)
+                        points.push(...response.data.results)
+                        i += 20
+                    } while (response.data.next);
 
 
-                setPoints(split.features[1].geometry.coordinates.map(c => [c[1], c[0]]))
-                
-            } catch (error) {
-                console.error(error)
+                    let longLat = points.map(p => [p.shape_pt_lon * 1, p.shape_pt_lat * 1])
+
+                    var line = turf.lineString(longLat);
+                    var pt = turf.point(stopCoords)
+                    var splitter = turf.nearestPointOnLine(line, pt)
+                    var split = turf.lineSplit(line, splitter);
+
+                    if (split.features.length === 1) {
+                        setPoints(split.features[0].geometry.coordinates.map(c => [c[1], c[0]]))
+                    } else {
+                        setPoints(split.features[1].geometry.coordinates.map(c => [c[1], c[0]]))
+
+                    }
+                } catch (error) {
+                    console.error(error)
+                }
             }
-        }
-        exec()
+            exec()
         }
 
-    }, [shape])
+    }, [sequenceInfo])
 
 
 

--- a/src/hooks/getTrips.jsx
+++ b/src/hooks/getTrips.jsx
@@ -14,6 +14,7 @@ export function TripProvider({ children }) {
     const [sequenceInfo, setSequenceInfo] = useState()
     const [allSequenceStops, setAllSequenceStops] = useState([])
     const [shape, setShape] = useState()
+    const [isLoading, setIsLoading] = useState(true)
 
     const tripSelector = (selectedTrip) => {
         setTrip(selectedTrip);
@@ -27,32 +28,36 @@ export function TripProvider({ children }) {
                 data.results.forEach((item) => { allStops.push(item) })
                 if (data.next) {
                     getAllStops(data.next)
+                } else {
+                    setIsLoading(false)
+                    setAllSequenceStops([...allStops])
                 }
 
-                setAllSequenceStops([...allStops])
 
             })
     }
 
     // GET SEQUENCESTOPS
     useEffect(() => {
-        if(trip){
+        if (trip) {
             setStopInfo(trip)
             setShape(trip.shape_id)
             getAllStops(`/stop_times/?trip_id=${trip.trip_id}&direction_id=${trip.direction_id}`)
         }
     }, [trip])
 
-    useEffect(() => {   
-        const sortedSequence = allSequenceStops.sort((a,b) => {a.stop_sequence - b.stop_sequence})
-        if (locationType === 1) {
-            const mapSequence = sortedSequence?.map(e => e.stop_id.stop_name).indexOf(name) 
-            const filteredSequence = sortedSequence?.splice(mapSequence)
-            setSequenceInfo(filteredSequence)
-        } else {
-            const mapSequence = sortedSequence?.map(e => e.stop_id.stop_id).indexOf(stopId)
-            const filteredSequence = sortedSequence?.splice(mapSequence)
-            setSequenceInfo(filteredSequence)
+    useEffect(() => {
+        if (!isLoading) {
+            const sortedSequence = allSequenceStops.sort((a, b) => { a.stop_sequence - b.stop_sequence })
+            if (locationType === 1) {
+                const mapSequence = sortedSequence?.map(e => e.stop_id.stop_name).indexOf(name)
+                const filteredSequence = sortedSequence?.splice(mapSequence)
+                setSequenceInfo(filteredSequence)
+            } else {
+                const mapSequence = sortedSequence?.map(e => e.stop_id.stop_id).indexOf(stopId)
+                const filteredSequence = sortedSequence?.splice(mapSequence)
+                setSequenceInfo(filteredSequence)
+            }
         }
     }, [allSequenceStops])
     return (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -142,7 +142,7 @@ export function Home() {
                         <LayerGroup>
                           {tracked ? tracked.map((e) => {
                                 return <div>
-                                    <BusMarker id={e.code} data={e} icon={L.divIcon(
+                                    <BusMarker key={e.code} id={e.code} data={e} icon={L.divIcon(
                                         markerOptions(e)
                                     )} />
                                 </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -33,7 +33,7 @@ import { MovingMarkerContext } from "../hooks/getMovingMarkers";
 export function Home() {
 
     const { center, setCode } = useContext(CodeContext)
-    const {tracked, arrivals } = useContext(MovingMarkerContext)
+    const { tracked, arrivals } = useContext(MovingMarkerContext)
     const { points } = useContext(ShapeContext)
     const { trip, sequenceInfo, stopInfo } = useContext(TripContext)
     const { activeForm } = useContext(FormContext)
@@ -100,9 +100,6 @@ export function Home() {
         }
     }
 
-
-
-
     return (
         <>
             <Header />
@@ -131,16 +128,16 @@ export function Home() {
                         />
                         <div id="map"></div>
                         <ComponentResize />
-                        {sequenceInfo ? 
+                        {sequenceInfo && points ?
+                            <LayerGroup>
+                                {sequenceInfo.map((e) => (
+                                    <Marker key={e.id} position={[e.stop_id.stop_lat, e.stop_id.stop_lon]} icon={normalMarker} />
+                                ))}
+                                <Polyline pathOptions={blackOptions} positions={points} /> : <></>
+                            </LayerGroup>
+                            : <></>}
                         <LayerGroup>
-                            {sequenceInfo.map((e) => (
-                                <Marker key={e.id} position={[e.stop_id.stop_lat, e.stop_id.stop_lon]} icon={normalMarker} />
-                            ))}
-                            {points ? <Polyline pathOptions={blackOptions} positions={points} /> : <></>}
-                        </LayerGroup>
-                        : <></>}
-                        <LayerGroup>
-                          {tracked ? tracked.map((e) => {
+                            {tracked ? tracked.map((e) => {
                                 return <div>
                                     <BusMarker key={e.code} id={e.code} data={e} icon={L.divIcon(
                                         markerOptions(e)
@@ -150,7 +147,7 @@ export function Home() {
 
                         </LayerGroup>
                         <Marker position={center} icon={yourPosition} />
-                        <CenterButton location={center}/>
+                        <CenterButton location={center} />
                     </MapContainer>}
             </div>
 


### PR DESCRIPTION
### Mudanças
- dfaf110d10f4a91efa30b7730afeb455a92e9a18: Antes era retirado do array as trips que não tinham ETA, sendo assim, as informações no card eram incompletas. Agora aparece mesmo se não tem ETA
- 7bc922772c8b8dd8b044f9761c702ee8306f512a: Shapes de pontos inicias apareciam incorretamente pois a lógica aplicada para mostrar não levava em conta esses pontos inicias que não possuem shape anterior a ele. Estações BRT estavam com plataformas incompletas também, a mudança feita foi para buscar todas as páginas de stop_times e só quando não houvesse mais próxima página ele "seta" as plataformas