### PR TITLE
🐛 Fix: Buscas sem service_id corrigidas

### DIFF
--- a/src/hooks/getServiceId.jsx
+++ b/src/hooks/getServiceId.jsx
@@ -10,7 +10,7 @@ export const ServiceIdContext = createContext()
 
 
 export function ServiceIdProvider({ children }) {
-    const {code} = useContext(CodeContext)
+    const { code } = useContext(CodeContext)
     const [today, setToday] = useState('')
     const [calendar, setCalendar] = useState([])
     const [serviceId, setServiceId] = useState('')
@@ -22,7 +22,7 @@ export function ServiceIdProvider({ children }) {
 
 
     async function getDates(url) {
-        let allDates = []; 
+        let allDates = [];
         await api
             .get(url)
             .then(({ data }) => {
@@ -36,33 +36,35 @@ export function ServiceIdProvider({ children }) {
             });
     }
     async function getDayOfWeek(url) {
-        let allDay = []; 
+        let allDay = [];
         await api
             .get(url)
             .then(({ data }) => {
                 data.results.forEach((item) => {
                     allDay.push(item);
                 });
-                
+
                 setWeekDay(allDay);
             });
     }
-
-
     useEffect(() => {
-        if(code){
-        getDates('calendar_dates/')
-        getDayOfWeek('calendar/')
         const date = new Date();
         const year = date.getFullYear();
         const month = String(date.getMonth() + 1).padStart(2, '0');
         const day = String(date.getDate()).padStart(2, '0');
         const formattedDate = `${year}-${month}-${day}`;
         setToday(formattedDate)
+    }, [])
+
+
+    useEffect(() => {
+        if (code.length > 0) {
+            getDayOfWeek('calendar/')
+            getDates('calendar_dates/')
         }
     }, [code])
 
-   
+
     function findService(todayDate) {
         const service = calendar.find((item) => item.date === todayDate);
         if (service) {
@@ -87,7 +89,9 @@ export function ServiceIdProvider({ children }) {
 
 
     useEffect(() => {
+        if (calendar.length > 0) {
             findService(today)
+        }
     }, [calendar])
 
 


### PR DESCRIPTION
### Mudanças
- 04c45c0c12c8aa28a44331974f22a36f7b50e5b3: Antes de ser buscado e definido o service_id as buscas que precisavam dele eram feitas mesmo sem ele, então agora foi feito condicionais para setar o service_id e impedir buscas com ele vazio