### PR TITLE
⚙️ Fix: Ajustes no card de info

### DIFF
--- a/src/components/InfoCard/InfoCard.jsx
+++ b/src/components/InfoCard/InfoCard.jsx
@@ -91,7 +91,7 @@ export function InfoCard() {
                     <h1 className="text-xl font-semibold mb-3">{name}</h1>
                     {linha ?
                         <p className='text-[#707070] text-sm'>Veja o próximo ônibus na estação:</p> :
-                        <p className='text-[#707070] text-sm'>Selecione o sentido para mais informações:</p>
+                        <p className='text-[#707070] text-sm'>Selecione a plataforma para mais informações:</p>
                     }
                     <ul className={styles.routeList}>
                         {!routes ? <>

--- a/src/components/InfoCard/styles.module.scss
+++ b/src/components/InfoCard/styles.module.scss
@@ -24,7 +24,6 @@
             border-radius: 3px;
             padding: 4px 3px;
             min-width:  45.5px;
-            max-height: 24px;
 
 
         }


### PR DESCRIPTION
## Mudanças
- ajuste de texto ( o sentido --> a plataforma)
- ajuste de CSS, quando o texto quebrava o background amarelo não acompanhava a quebra